### PR TITLE
fix(coreos-setgoodroot): Remove invalid use of 'local'.

### DIFF
--- a/coreos-setgoodroot
+++ b/coreos-setgoodroot
@@ -9,9 +9,9 @@
 . "$(dirname "$0")/chromeos-common.sh" || exit 1
 
 if [ "0" = $(id -u) ]; then
-  local sudo=""
+  sudo=""
 else
-  local sudo=sudo
+  sudo=sudo
 fi
 
 # Extract the kernel partition's UniqueGuid from the command line.


### PR DESCRIPTION
Turns out this error wasn't harmless after all because -e was set in the
shebang line. This means our system never marks newly upgraded systems
as good and will roll back after the next reboot. This appears to be a
bug that has existed since the script's introduction in a51e35b2 so it
is really surprising it hasn't come up before.
